### PR TITLE
chore: Run build on 'prepack' instead of 'prepare'

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "tsc --noEmit && eslint --fix --ignore-path .gitignore .",
     "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\"",
     "coverage": "c8 --reporter=lcov npm test",
-    "prepare": "npm run build"
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should save time during local install (when developing this
package) and during CI.